### PR TITLE
add core nxc smb usage examples

### DIFF
--- a/services/smb
+++ b/services/smb
@@ -8,3 +8,10 @@ Recursive directory listing:smbmap -H $ip -R
 Create a destination mount directory, mount remote share as guest:sudo mkdir /mnt/$IP_$FOLDER; sudo mount -v -t cifs "//$IP/$FOLDER" /mnt/$IP_$FOLDER -o username=guest
 smbclient - (unauthenticated) - Connect to remote smb share as null user:smbclient "//$IP/$SHARE_NAME" -U ""
 Scan IP Address for SMB Pipe Names:pipef -a $IP
+nxc smb - Check with null user:nxc smb $IP -u '' -p ''
+nxc smb - Check with anonymous user:nxc smb $IP -u 'notexistantuser' -p ''
+nxc smb - Connect with valid credentials:nxc smb $IP -u "$USERNAME" -p "$PASSWORD"
+nxc smb - List available shares:nxc smb $IP -u "$USERNAME" -p "$PASSWORD" --shares
+nxc smb - List domain users:nxc smb $IP -u "$USERNAME" -p "$PASSWORD" --users
+nxc smb - RID brute force (anonymous):nxc smb $IP -u 'notexistantuser' -p '' --rid-brute
+nxc smb - Run authenticated module (example spider_plus):nxc smb $IP -u "$USERNAME" -p "$PASSWORD" -M spider_plus


### PR DESCRIPTION
- Added baseline nxc smb commands for common enumeration and auth cases:
  • Null user check
  • Anonymous user check (using non-existent username)
  • Connect with valid credentials
  • List available shares
  • List domain users
  • RID brute force with anonymous user
  • Example authenticated module execution (spider_plus)
- Keeps the base usage separate from module loop commands for clarity
