### PR TITLE
add core dig DNS enumeration examples with explanations

### DIFF
--- a/services/dns
+++ b/services/dns
@@ -3,3 +3,8 @@ Nameserver lookup:host -t ns $DOMAIN
 nmap scan a subnet using a custom dns server :nmap -F --dns-server $IP_DNS_SERVER $SUBNET
 gobuster subdomain enumeration (top one million):gobuster -d $DOMAIN -w /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -t 30
 amass subdomain enumeration: amass enum -v -src -ip -brute -min-for-recursive 2 -d $DOMAIN
+dig - NS (authoritative nameservers):dig @$DNS_SERVER $DOMAIN NS +noall +answer
+dig - A and AAAA (IPv4 and IPv6):dig @$DNS_SERVER $DOMAIN A AAAA +noall +answer
+dig - MX (mail exchangers):dig @$DNS_SERVER $DOMAIN MX +noall +answer
+dig - TXT (SPF, DMARC, misc):dig @$DNS_SERVER $DOMAIN TXT +noall +answer
+dig - ANY (all records server is willing to reveal):dig @$DNS_SERVER $DOMAIN ANY +noall +answer


### PR DESCRIPTION
- Added documentation for core dig usage in CTF and pentest contexts
- Covered the following queries with command syntax, example output, and meaning:
  • SOA and NS (authority and nameservers)
  • ANY (server willing to reveal all records, often restricted)
  • Core records (A, AAAA, CNAME, MX, TXT)
  • SRV records for Active Directory (LDAP, Kerberos, Kpasswd, DC locator)
  • AXFR (zone transfer attempt)
  • PTR (reverse lookup of DNS server IP)
  • Subdomain brute-force (wordlist-driven)
  • Quick summary (NS, MX, TXT, A with short output)
